### PR TITLE
Fix of buildTransitive feature of package

### DIFF
--- a/src/GitInfo/GitInfo.msbuildproj
+++ b/src/GitInfo/GitInfo.msbuildproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <None Include="build/**/*.*" />
     <None Include="buildMultiTargeting/**/*.*" />
+    <None Include="buildTransitive/**/*.*" />
     <None Include="..\..\readme.md" PackagePath="readme.md" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
`buildTransitive` feature was accidentally removed when migrating to newer approach in a91737172870e470dc6fecb20f03dca546e6ee0e in https://github.com/devlooped/GitInfo/pull/168

closing #154 

cc: @kzu 