### PR TITLE
Fix "MSBuild customizations" misnomer & add link to documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,7 +160,7 @@ The available constants from code are:
   ThisAssembly.Git.IsDirty
 ```
 
-Available MSBuild customizations:
+Available [MSBuild properties](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-properties):
 
 ```
   $(GitThisAssembly): set to 'false' to prevent assembly 


### PR DESCRIPTION
This will make it easier for people to understand how to use the MSBuild properties.