### PR TITLE
Switch to built-in .NET SDK AssemblyMetadata support

### DIFF
--- a/src/GitInfo/build/GitInfo.AssemblyMetadata.targets
+++ b/src/GitInfo/build/GitInfo.AssemblyMetadata.targets
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  ==============================================================
+              Provides assembly-level metadata
+              for Git information.
+
+	$(GitThisAssemblyMetadata): set to 'false' to prevent assembly
+  								metadata generation. Defaults to 'false'.           
+	==============================================================
+	-->
+
+  <PropertyGroup>
+    <GitThisAssemblyMetadata Condition="'$(GitThisAssemblyMetadata)' == ''">false</GitThisAssemblyMetadata>
+  </PropertyGroup>
+
+  <Target Name="GitAssemblyMetadata" DependsOnTargets="GitInfo;GitVersion"
+          BeforeTargets="BuildOnlySettings" Condition="'$(GitThisAssemblyMetadata)' == 'true'">
+
+    <ItemGroup Condition="'$(Language)' != 'VB'">
+      <AssemblyMetadata Include="GitInfo.IsDirty"
+                        Condition="'$(GitRoot)' == ''"
+                        Value="false" />
+      <AssemblyMetadata Include="GitInfo.IsDirty"
+                        Condition="'$(GitIsDirty)' != '0'"
+                        Value="true" />
+      <AssemblyMetadata Include="GitInfo.IsDirty"
+                        Condition="'$(GitIsDirty)' == '0'"
+                        Value="false" />
+    </ItemGroup>
+
+    <!-- For backwards-compatibility reasons, we keep the VB casing on these -->
+    <ItemGroup Condition="'$(Language)' == 'VB'">
+      <AssemblyMetadata Include="GitInfo.IsDirty"
+                        Condition="'$(GitRoot)' == ''"
+                        Value="False" />
+      <AssemblyMetadata Include="GitInfo.IsDirty"
+                        Condition="'$(GitIsDirty)' != '0'"
+                        Value="True" />
+      <AssemblyMetadata Include="GitInfo.IsDirty"
+                        Condition="'$(GitIsDirty)' == '0'"
+                        Value="False" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <AssemblyMetadata Include="GitInfo.RepositoryUrl" Value="$(GitRepositoryUrl)" />
+      <AssemblyMetadata Include="GitInfo.Branch" Value="$(GitBranch)" />
+      <AssemblyMetadata Include="GitInfo.Commit" Value="$(GitCommit)" />
+      <AssemblyMetadata Include="GitInfo.Commits" Value="$(GitCommits)" />
+      <AssemblyMetadata Include="GitInfo.CommitDate" Value="$(GitCommitDate)" />
+      <AssemblyMetadata Include="GitInfo.Sha" Value="$(GitSha)" />
+      <AssemblyMetadata Include="GitInfo.BaseVersion" Value="$(GitBaseVersion)" />
+      <AssemblyMetadata Include="GitInfo.BaseVersion.Major" Value="$(GitBaseVersionMajor)" />
+      <AssemblyMetadata Include="GitInfo.BaseVersion.Minor" Value="$(GitBaseVersionMinor)" />
+      <AssemblyMetadata Include="GitInfo.BaseVersion.Patch" Value="$(GitBaseVersionPatch)" />
+      <AssemblyMetadata Include="GitInfo.Tag" Value="$(GitTag)" />
+      <AssemblyMetadata Include="GitInfo.BaseTag" Value="$(GitBaseTag)" />
+      <AssemblyMetadata Include="GitInfo.SemVer.Major" Value="$(GitSemVerMajor)" />
+      <AssemblyMetadata Include="GitInfo.SemVer.Minor" Value="$(GitSemVerMinor)" />
+      <AssemblyMetadata Include="GitInfo.SemVer.Patch" Value="$(GitSemVerPatch)" />
+      <AssemblyMetadata Include="GitInfo.SemVer.Label" Value="$(GitSemVerLabel)" />
+      <AssemblyMetadata Include="GitInfo.SemVer.DashLabel" Value="$(GitSemVerDashLabel)" />
+      <AssemblyMetadata Include="GitInfo.SemVer.Source" Value="$(GitSemVerSource)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/GitInfo/build/GitInfo.cs.pp
+++ b/src/GitInfo/build/GitInfo.cs.pp
@@ -3,27 +3,6 @@
 #define $MetadataDefine$
 #pragma warning disable 0436
 
-#if ADDMETADATA
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.IsDirty", RootNamespace.ThisAssembly.Git.IsDirtyString)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.RepositoryUrl", RootNamespace.ThisAssembly.Git.RepositoryUrl)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.Branch", RootNamespace.ThisAssembly.Git.Branch)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.Commit", RootNamespace.ThisAssembly.Git.Commit)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.Sha", RootNamespace.ThisAssembly.Git.Sha)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.CommitDate", RootNamespace.ThisAssembly.Git.CommitDate)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseVersion.Major", RootNamespace.ThisAssembly.Git.BaseVersion.Major)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseVersion.Minor", RootNamespace.ThisAssembly.Git.BaseVersion.Minor)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseVersion.Patch", RootNamespace.ThisAssembly.Git.BaseVersion.Patch)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.Commits", RootNamespace.ThisAssembly.Git.Commits)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.Tag", RootNamespace.ThisAssembly.Git.Tag)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseTag", RootNamespace.ThisAssembly.Git.BaseTag)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Major", RootNamespace.ThisAssembly.Git.SemVer.Major)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Minor", RootNamespace.ThisAssembly.Git.SemVer.Minor)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Patch", RootNamespace.ThisAssembly.Git.SemVer.Patch)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Label", RootNamespace.ThisAssembly.Git.SemVer.Label)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.DashLabel", RootNamespace.ThisAssembly.Git.SemVer.DashLabel)]
-[assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Source", RootNamespace.ThisAssembly.Git.SemVer.Source)]
-#endif
-
 #if LOCALNAMESPACE
 namespace _RootNamespace_
 {

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -1134,6 +1134,7 @@
     </PropertyGroup>
   </Target>
 
+  <Import Project="GitInfo.AssemblyMetadata.targets"/>
   <PropertyGroup>
     <GitInfoImported>true</GitInfoImported>
   </PropertyGroup>

--- a/src/GitInfo/build/GitInfo.vb.pp
+++ b/src/GitInfo/build/GitInfo.vb.pp
@@ -2,27 +2,6 @@
 #Const $NamespaceDefine$ = 1
 #Const $MetadataDefine$ = 1
 
-#If ADDMETADATA
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.IsDirty", Global.RootNamespace.ThisAssembly.Git.IsDirtyString)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.RepositoryUrl", Global.RootNamespace.ThisAssembly.Git.RepositoryUrl)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.Branch", Global.RootNamespace.ThisAssembly.Git.Branch)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.Commit", Global.RootNamespace.ThisAssembly.Git.Commit)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.Sha", Global.RootNamespace.ThisAssembly.Git.Sha)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.CommitDate", Global.RootNamespace.ThisAssembly.Git.CommitDate)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseVersion.Major", Global.RootNamespace.ThisAssembly.Git.BaseVersion.Major)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseVersion.Minor", Global.RootNamespace.ThisAssembly.Git.BaseVersion.Minor)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseVersion.Patch", Global.RootNamespace.ThisAssembly.Git.BaseVersion.Patch)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.Commits", Global.RootNamespace.ThisAssembly.Git.Commits)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.Tag", Global.RootNamespace.ThisAssembly.Git.Tag)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.BaseTag", Global.RootNamespace.ThisAssembly.Git.BaseTag)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Major", Global.RootNamespace.ThisAssembly.Git.SemVer.Major)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Minor", Global.RootNamespace.ThisAssembly.Git.SemVer.Minor)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Patch", Global.RootNamespace.ThisAssembly.Git.SemVer.Patch)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Label", Global.RootNamespace.ThisAssembly.Git.SemVer.Label)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.DashLabel", Global.RootNamespace.ThisAssembly.Git.SemVer.DashLabel)>
-<Assembly: System.Reflection.AssemblyMetadata("GitInfo.SemVer.Source", Global.RootNamespace.ThisAssembly.Git.SemVer.Source)>
-#End If
-
 #If LOCALNAMESPACE
 Namespace Global._RootNamespace_
 #Else


### PR DESCRIPTION
Instead of our custom label and code generation, we can simply provide @(AssemblyMetadata) items that the SDK can turn into the right metadata attributes.

This future proofs this for F#, should it support it too (which we don't in our current template file).