### PR TITLE
Properly detect HEAD changes for incremental builds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,13 @@ Available [MSBuild properties](https://learn.microsoft.com/en-us/visualstudio/ms
            performance reasons.
            Defaults to empty value (no ignoring).
 
+  $(GitCachePath): where to cache the determined Git information
+				   gives the chance to use a shared location
+				   for different projects. this can improve
+				   the overall build time.
+				   has to end with a path seperator
+				   Defaults to empty value ('$(IntermediateOutputPath)').
+
   $(GitNameRevOptions): Options passed to git name-rev when finding
               a branch name for the current commit (Detached head). The default is
               '--refs=refs/heads/* --no-undefined --alwas'

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -969,6 +969,27 @@
 
   </Target>
 
+  <!-- This combination of prop/item/target fix incremental builds after HEAD changes. -->
+  <PropertyGroup>
+    <_GitCacheFullPath>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(GitCachePath)))</_GitCacheFullPath>
+    <!-- We read the path to the HEAD file, written in a previously run _GitWriteHeadPath target -->
+    <_GitHeadPath Condition="Exists('$(_GitCacheFullPath)GitHead.cache')">$([System.IO.File]::ReadAllText('$(_GitCacheFullPath)GitHead.cache').Trim())</_GitHeadPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- And if the HEAD path exists, we add it as an input for the fast up-to-date check VS performs -->
+    <UpToDateCheckInput Condition="'$(_GitHeadPath)' != '' and Exists('$(_GitHeadPath)')" Include="$(_GitHeadPath)" />
+  </ItemGroup>
+
+  <!-- NOTE: we write the path to HEAD after first calculating a version, since we can be anywhere in 
+       the solution structure. This file will only be written if there's a change in the git root, 
+       which should never happen. -->
+  <Target Name="_GitWriteHeadPath" AfterTargets="GitVersion">
+    <WriteLinesToFile Lines="$(GitRoot).git\HEAD"
+						  File="$(GitCachePath)GitHead.cache"
+						  Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+
   <!--
     ============================================================
               GitExe Property


### PR DESCRIPTION
When the current HEAD is changed within VS, we currently don't surface any changes and the IDE thinks there's nothing to update. But obviously GitInfo would need to calculate again all the info.

This commit takes the ideas from #186 by @brunom, integrates into GitInfo and surfaces it to VS seamlessly so users don't have to customize anything and it Just Works.

Closes #186