### PR TITLE
Switch to ThisAssembly.Constants for C#

### DIFF
--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.2.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
   </ItemGroup>  
 
 </Project>

--- a/src/GitInfo/GitInfo.msbuildproj
+++ b/src/GitInfo/GitInfo.msbuildproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.0.4">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>GitInfo</PackageId>
     <Description>Access commit information from MSBuild and C#/F#/VB code, and infer SemVer from branch, tag or version file in Git repository.</Description>
     <PackageTags>MSBuild Git Versioning GitVersion GitFlowVersion GitFlow GitHubFlow SemVer</PackageTags>
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Constants" Version="1.2.5" Pack="true" TargetFramework="netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build/**/*.*" />

--- a/src/GitInfo/build/GitInfo.ThisAssembly.targets
+++ b/src/GitInfo/build/GitInfo.ThisAssembly.targets
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+  ==============================================================
+              Leverages ThisAssembly.Constants generator
+              to expose assembly info constants
+
+	$(GitThisAssembly): set to 'false' to prevent assembly
+						metadata and constants generation.
+
+	==============================================================
+	-->
+
+  <PropertyGroup>
+    <GitThisAssembly Condition="'$(GitThisAssembly)' == ''">true</GitThisAssembly>
+  </PropertyGroup>
+
+  <!-- Private properties -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>
+      GitInfo;
+      GitVersion;
+      GitThisAssembly;
+      GitInfoReport;
+      $(CoreCompileDependsOn)
+    </CoreCompileDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GitThisAssemblyDependsOn>
+      GitInfo;
+      GitVersion;
+    </GitThisAssemblyDependsOn>
+  </PropertyGroup>
+
+  <Target Name="GitThisAssembly" DependsOnTargets="$(GitThisAssemblyDependsOn)"
+			    BeforeTargets="PrepareConstants" Condition="'$(GitThisAssembly)' == 'true'">
+
+    <ItemGroup>
+      <Constant Include="IsDirty" Value="$(IsDirty)" Root="Git" />
+      <Constant Include="IsDirtyString" Value="$(IsDirtyString)" Root="Git" />
+      <Constant Include="RepositoryUrl" Value="$(GitRepositoryUrl)" Root="Git" />
+      
+      <Constant Include="Branch" Value="$(GitBranch)" Root="Git" />
+      <Constant Include="Commit" Value="$(GitCommit)" Root="Git" />
+      <Constant Include="Sha" Value="$(GitSha)" Root="Git" />
+      <Constant Include="CommitDate" Value="$(GitCommitDate)" Root="Git" />
+      <Constant Include="Commits" Value="$(GitCommits)" Root="Git" />
+      
+      <Constant Include="Tag" Value="$(GitTag)" Root="Git" />
+      <Constant Include="BaseTag" Value="$(GitBaseTag)" Root="Git" />
+      <Constant Include="BaseVersion.Major" Value="$(GitBaseVersionMajor)" Root="Git" />
+      <Constant Include="BaseVersion.Minor" Value="$(GitBaseVersionMinor)" Root="Git" />
+      <Constant Include="BaseVersion.Patch" Value="$(GitBaseVersionPatch)" Root="Git" />
+      <Constant Include="SemVer.Major" Value="$(GitSemVerMajor)" Root="Git" />
+      <Constant Include="SemVer.Minor" Value="$(GitSemVerMinor)" Root="Git" />
+      <Constant Include="SemVer.Patch" Value="$(GitSemVerPatch)" Root="Git" />
+      <Constant Include="SemVer.Label" Value="$(GitSemVerLabel)" Root="Git" />
+      <Constant Include="SemVer.DashLabel" Value="$(GitSemVerDashLabel)" Root="Git" />
+      <Constant Include="SemVer.Source" Value="$(GitSemVerSource)" Root="Git" />
+    </ItemGroup>    
+    
+  </Target>
+
+</Project>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -1062,7 +1062,8 @@
   </Target>
 
   <Import Project="GitInfo.AssemblyInfo.targets"/>
-  <Import Project="GitInfo.AssemblyMetadata.targets"/>
+  <Import Project="GitInfo.AssemblyMetadata.targets" Condition="'$(Language)' != 'C#' or '$(ThisAssemblyNamespace)' != ''"/>
+  <Import Project="GitInfo.ThisAssembly.targets" Condition="'$(Language)' == 'C#'"/>
 
   <PropertyGroup>
     <GitInfoImported>true</GitInfoImported>


### PR DESCRIPTION
The approach for codegen in ThisAssembly uses the much better incremental source generators in Roslyn to expose this information. Make it so we leverage that for the scenarios that ThisAssembly.Constants already supports too.