### PR TITLE
Set Version and PackageVersion to a default value

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" InitialTargets="SetGitExe" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" InitialTargets="SetGitExe;GitSetVersion" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
   ==============================================================
               Retrieves and exposes Git information
@@ -12,12 +12,18 @@
 
 	Customization:
 
+  $(GitVersion): set to 'false' to avoid setting Version and PackageVersion 
+                 to a default version with format: 
+                 $(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)$(GitSemVerDashLabel)+$(GitBranch).$(GitCommit)
+
 	$(GitThisAssembly): set to 'false' to prevent assembly
 						metadata and constants generation.
 
-	$(GitThisAssemblyMetadata): set to 'false' to prevent assembly
-  								metadata generation only. Defaults
-								to 'false'.
+  $(GitThisAssemblyMetadata): set to 'false' to prevent assembly 
+                              metadata generation only. Defaults 
+                              to 'false'. If 'true', it will also 
+                              provide assembly metadata attributes 
+                              for each of the populated values.
 
 	$(ThisAssemblyNamespace): allows overriding the namespace
 							  for the ThisAssembly class.
@@ -562,6 +568,13 @@
   </PropertyGroup>
 
   <Target Name="GitVersion" DependsOnTargets="$(GitVersionDependsOn)" Returns="@(GitInfo)" />
+
+  <Target Name="GitSetVersion" DependsOnTargets="GitVersion" Condition="'$(GitVersion)' != 'false'">
+      <PropertyGroup>
+          <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)$(GitSemVerDashLabel)+$(GitBranch).$(GitCommit)</Version>
+          <PackageVersion>$(Version)</PackageVersion>
+      </PropertyGroup>
+  </Target>  
 
   <Target Name="_GitBaseVersionFile" Returns="$(GitBaseVersion)"
 			Inputs="@(_GitInput)"


### PR DESCRIPTION
It's not entirely intuitive that you install GitInfo and by default "nothing happens", as in, you get new code from ThisAssembly, but otherwise, no versioning changes happen. This might be counterintuitive to newcomers, who might just care to get something (a sensible default) going, before investing more in customizing GitInfo.

This is how MinVer does it (provided there's a version tag in the repository) and it's quite intuitive.

The way we do it here should be mostly backwards compat because:
1. Users leveraging assembly-version attributes will already have disabled .NET SDK assembly attribute generation
2. Users leveraging MSBuild targets to do this would be following the recommended guidance of creating a target that runs before specific targets, not as InitialTargets

We make our version-setting target run as an inital target, which may have a minor impact on initial build perf, but but shouldn't be a problem since the same targets are run for DTB anyway (if you make them run before
GetAssemblyVersion, which also runs before
BeforeCompile and CoreCompile in the SDK).

By being an initial target, we allow for existing customization in pretty much any target, prevail our own one, which becomes just a default.

Even so, we check for GitVersion=false as an escape hatch for users who may encounter unforseen broken scenarios.