### PR TITLE
Make sure we don't surface SponsorLink as an API

### DIFF
--- a/src/Analyzer/CodeAnalysis.csproj
+++ b/src/Analyzer/CodeAnalysis.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.2.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.5" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.5" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
   </ItemGroup>  
 
 </Project>


### PR DESCRIPTION
When taking a dependency on SponsorLink, we should only depend on the build+analyzer artifacts in the pacakge.