### PR TITLE
Replace / and \ in branches with dashes

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -571,7 +571,7 @@
 
   <Target Name="GitSetVersion" DependsOnTargets="GitVersion" Condition="'$(GitVersion)' != 'false'">
       <PropertyGroup>
-          <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)$(GitSemVerDashLabel)+$(GitBranch).$(GitCommit)</Version>
+          <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)$(GitSemVerDashLabel)+$(GitBranch.Replace('/', '-').Replace('\', '-')).$(GitCommit)</Version>
           <PackageVersion>$(Version)</PackageVersion>
       </PropertyGroup>
   </Target>  


### PR DESCRIPTION
Do this only when setting a default Version since otherwise the build fails. But we don't want to change the determined GitBranch so it remains accurate.

Closes #244 and #240