### PR TITLE
Set AzureDevOps branch name also for PR

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -69,6 +69,7 @@
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(GITHUB_REF)' != '' and $(GITHUB_REF.Contains('refs/pull/'))">pr$(GITHUB_REF.Replace('refs/pull/', '').Replace('/merge', ''))</RepositoryBranch>
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(GITHUB_REF)' != ''">$(GITHUB_REF.Replace('refs/heads/', '').Replace('refs/tags/', ''))</RepositoryBranch>
     <!-- Azure DevOps: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables -->
+    <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(BUILD_SOURCEBRANCHNAME)' == 'merge' and '$(SYSTEM_PULLREQUEST_SOURCEBRANCH)' != ''">$(SYSTEM_PULLREQUEST_SOURCEBRANCH.Replace('refs/heads/', '').Replace('refs/tags/', ''))</RepositoryBranch>
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(BUILD_SOURCEBRANCH)' != ''">$(BUILD_SOURCEBRANCH.Replace('refs/heads/', '').Replace('refs/tags/', ''))</RepositoryBranch>
     <!-- AppVeyor: https://www.appveyor.com/docs/environment-variables/ -->
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''">pr$(APPVEYOR_PULL_REQUEST_NUMBER)</RepositoryBranch>


### PR DESCRIPTION
Hi,
I discovered that GitInfo does not catch the correct branch name for the PullRequest build in Azure DevOps.
It should be fixed with this PR

Here are screenshots from `env` in PR pipeline:
![PR_REF_PULL](https://user-images.githubusercontent.com/3594540/221551948-3b8ed571-af36-4c93-b1ec-8b15593bd576.png)
![PR_SOURCEBRANCHNAME](https://user-images.githubusercontent.com/3594540/221551950-db1a3cc9-1f53-4561-aa04-469f79a0d3a0.png)
![PR_sourcebranch](https://user-images.githubusercontent.com/3594540/221551949-7c1483dc-f5c2-45f3-b2fd-d8f022b82f1e.png)
