### PR TITLE
Fix backs-compat generation when custom namespace in use

### DIFF
--- a/src/GitInfo/build/GitInfo.AssemblyMetadata.targets
+++ b/src/GitInfo/build/GitInfo.AssemblyMetadata.targets
@@ -10,12 +10,7 @@
 	==============================================================
 	-->
 
-  <PropertyGroup>
-    <GitThisAssemblyMetadata Condition="'$(GitThisAssemblyMetadata)' == ''">false</GitThisAssemblyMetadata>
-  </PropertyGroup>
-
-  <Target Name="GitAssemblyMetadata" DependsOnTargets="GitInfo;GitVersion"
-          BeforeTargets="BuildOnlySettings" Condition="'$(GitThisAssemblyMetadata)' == 'true'">
+  <Target Name="GitAssemblyMetadata" DependsOnTargets="GitInfo;GitVersion" BeforeTargets="BuildOnlySettings">
 
     <ItemGroup Condition="'$(Language)' != 'VB'">
       <AssemblyMetadata Include="GitInfo.IsDirty"

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -1074,9 +1074,12 @@
     </PropertyGroup>
   </Target>
 
-  <Import Project="GitInfo.AssemblyInfo.targets"/>
-  <Import Project="GitInfo.AssemblyMetadata.targets" Condition="'$(Language)' != 'C#' or '$(ThisAssemblyNamespace)' != ''"/>
-  <Import Project="GitInfo.ThisAssembly.targets" Condition="'$(Language)' == 'C#'"/>
+  <Import Project="GitInfo.AssemblyMetadata.targets" Condition="'$(GitThisAssemblyMetadata)' == 'true'"/>
+
+  <!-- Legacy generation in place for non-C# or when the unsupported ThisAssemblyNamespace is in use -->
+  <Import Project="GitInfo.AssemblyInfo.targets" Condition="'$(Language)' != 'C#' or '$(ThisAssemblyNamespace)' != ''"/>
+  <!-- Otherwise, for C# we always use ThisAssembly instead. -->
+  <Import Project="GitInfo.ThisAssembly.targets" Condition="'$(Language)' == 'C#' and '$(ThisAssemblyNamespace)' == ''"/>
 
   <PropertyGroup>
     <GitInfoImported>true</GitInfoImported>


### PR DESCRIPTION
We were not properly conditioning the new ThisAssembly-based generation on the usage of a custom ThisAssemblyNamespace, causing P2P scenarios to fail since we were simultaneously generating in the custom namespace *and* the global one.

Fixes #258