### PR TITLE
Fix IsDirty generator when using a custom namespace

### DIFF
--- a/src/Analyzer/CodeAnalysis.csproj
+++ b/src/Analyzer/CodeAnalysis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>GitInfo.CodeAnalysis</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackFolder>analyzers/dotnet</PackFolder>
+    <PackFolder>analyzers/dotnet/roslyn4.0</PackFolder>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Analyzer/GitInfoGenerator.cs
+++ b/src/Analyzer/GitInfoGenerator.cs
@@ -5,13 +5,17 @@ class GitInfoGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterSourceOutput(
-            context.AdditionalTextsProvider
-                .Combine(context.AnalyzerConfigOptionsProvider)
-                .Combine(context.ParseOptionsProvider)
-                .Collect(),
-            (c, _) =>
+        var ns = context.AnalyzerConfigOptionsProvider
+            .Select((c, _) => c.GlobalOptions.TryGetValue("build_property.ThisAssemblyNamespace", out var ns)
+                && !string.IsNullOrEmpty(ns) ? ns : null);
+
+        context.RegisterSourceOutput(ns,
+            (c, ns) =>
             {
+                // Legacy codegen used for this scenario, emit nothing.
+                if (!string.IsNullOrEmpty(ns))
+                    return;
+
                 c.AddSource("ThisAssembly.Git.IsDirty.g",
                     $$"""
                     //------------------------------------------------------------------------------
@@ -24,6 +28,7 @@ class GitInfoGenerator : IIncrementalGenerator
                     //     the code is regenerated.
                     // </auto-generated>
                     //------------------------------------------------------------------------------
+
                     partial class ThisAssembly
                     {
                         partial class Git

--- a/src/GitInfo/buildMultiTargeting/GitInfo.targets
+++ b/src/GitInfo/buildMultiTargeting/GitInfo.targets
@@ -8,6 +8,8 @@
     <!-- This makes sure we don't enforce SponsorLink transitively, but only when 
          consumers are directly referencing our package. -->
     <SponsorablePackageId Include="GitInfo" />
+
+    <CompilerVisibleProperty Include="ThisAssemblyNamespace" />
   </ItemGroup>
 
 	<Import Project="..\build\GitInfo.targets"/>

--- a/src/GitInfo/buildTransitive/GitInfo.targets
+++ b/src/GitInfo/buildTransitive/GitInfo.targets
@@ -8,6 +8,8 @@
     <!-- This makes sure we don't enforce SponsorLink transitively, but only when 
          consumers are directly referencing our package. -->
     <SponsorablePackageId Include="GitInfo" />
+
+    <CompilerVisibleProperty Include="ThisAssemblyNamespace" />
   </ItemGroup>
 
   <Import Project="..\build\GitInfo.targets"/>


### PR DESCRIPTION
In this case, the generator shouldn't emit anything at all, since the legacy generation will be in place, which already emits the right IsDirty boolean property.