### PR TITLE
Allow forcing templated code gen for C#

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -1077,9 +1077,9 @@
   <Import Project="GitInfo.AssemblyMetadata.targets" Condition="'$(GitThisAssemblyMetadata)' == 'true'"/>
 
   <!-- Legacy generation in place for non-C# or when the unsupported ThisAssemblyNamespace is in use -->
-  <Import Project="GitInfo.AssemblyInfo.targets" Condition="'$(Language)' != 'C#' or '$(ThisAssemblyNamespace)' != ''"/>
+  <Import Project="GitInfo.AssemblyInfo.targets" Condition="'$(Language)' != 'C#' or '$(ThisAssemblyNamespace)' != '' or '$(UseTemplatedCode)' == 'true'"/>
   <!-- Otherwise, for C# we always use ThisAssembly instead. -->
-  <Import Project="GitInfo.ThisAssembly.targets" Condition="'$(Language)' == 'C#' and '$(ThisAssemblyNamespace)' == ''"/>
+  <Import Project="GitInfo.ThisAssembly.targets" Condition="'$(Language)' == 'C#' and '$(ThisAssemblyNamespace)' == '' and '$(UseTemplatedCode)' != 'true'"/>
 
   <PropertyGroup>
     <GitInfoImported>true</GitInfoImported>


### PR DESCRIPTION
By setting `UseTemplatedCode=true` in the project, even for C# you'd get the older behavior instead of the ThisAssembly-based one.