### PR TITLE
Fix missing code from missing dependency

### DIFF
--- a/src/GitInfo/GitInfo.msbuildproj
+++ b/src/GitInfo/GitInfo.msbuildproj
@@ -10,9 +10,9 @@
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.0.0" />
+    <PackageReference Include="NuGetizer" Version="1.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly.Constants" Version="1.2.12" Pack="true" TargetFramework="netstandard2.0" />
+    <PackageReference Include="ThisAssembly.Constants" Version="1.2.14" Pack="true" TargetFramework="netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build/**/*.*" />


### PR DESCRIPTION
A missing feature in NuGetizer (see https://github.com/devlooped/nugetizer/pull/388) caused our dependency on ThisAssembly.Constants to be lost now that it explicitly sets itself as PrivateAssets=all to prevent analyzer propagation to referenced projects.

This scenario (a package reference with PrivateAssets=all AND Pack=true) was not supported by NuGetizer.

We now do, so this bump is enough to fix the issue.

Fixes #281