### PR TITLE
"_" is not allowed in nuget version strings

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -571,7 +571,7 @@
 
   <Target Name="GitSetVersion" DependsOnTargets="GitVersion" Condition="'$(GitVersion)' != 'false'">
       <PropertyGroup>
-          <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)$(GitSemVerDashLabel)+$(GitBranch.Replace('/', '-').Replace('\', '-')).$(GitCommit)</Version>
+          <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)$(GitSemVerDashLabel)+$(GitBranch.Replace('/', '-').Replace('\', '-').Replace('_', '-').$(GitCommit)</Version>
           <PackageVersion>$(Version)</PackageVersion>
       </PropertyGroup>
   </Target>  


### PR DESCRIPTION
The problem is the same as in  #244 which was fixed in #248. This pr would simply replace all underscores in a branch name with dashes. 