### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/Analyzer/CodeAnalysis.csproj
+++ b/src/Analyzer/CodeAnalysis.csproj
@@ -7,10 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLinker.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="SponsorLinker.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NuGetizer" Version="1.0.5" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.1.0" />
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.1.0" />-->
   </ItemGroup>  
 
 </Project>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink