### PR TITLE
Shield from invalid git version

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -223,8 +223,12 @@
       <_GitCurrentVersion>$([System.Text.RegularExpressions.Regex]::Match("$(_GitOutput)", "\d+\.\d+\.\d+").Value)</_GitCurrentVersion>
     </PropertyGroup>
 
-    <Error Condition="$([System.Version]::Parse('$(_GitCurrentVersion)').CompareTo($([System.Version]::Parse('$(GitMinVersion)')))) &lt; 0"
-			   Text="Required minimum git version is $(GitMinVersion) but found $(_GitCurrentVersion)." />
+    <Warning Condition="$(_GitCurrentVersion) == ''"
+             Code="GI007"
+             Text="Could not determine git version from output '$(_GitOutput)'. Required minimum git version is $(GitMinVersion)." />
+
+    <Error Condition="$(_GitCurrentVersion) != '' and $([System.Version]::Parse('$(_GitCurrentVersion)').CompareTo($([System.Version]::Parse('$(GitMinVersion)')))) &lt; 0"
+			     Text="Required minimum git version is $(GitMinVersion) but found $(_GitCurrentVersion)." />
   </Target>
 
   <Target Name="_GitRoot" Returns="$(GitRoot)" Condition="'$(GitRoot)' == ''">


### PR DESCRIPTION
It seems sometimes `git --version` might return something that isn't a valid version number we can parse into major.minor.code.

The warning can be ignored with the code `GI007`.

Fixes #300