### PR TITLE
Disable rogue command echo

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -280,8 +280,8 @@
       <_IsGitFile>$([System.IO.File]::Exists('$(GitDir)'))</_IsGitFile>
     </PropertyGroup>
 
-    <Exec Condition="'$(_IsGitFile)' == 'true'"
-			  Command='$(GitExe) rev-parse --is-inside-work-tree'
+    <Exec Command='$(GitExe) rev-parse --is-inside-work-tree'
+			  Condition="'$(_IsGitFile)' == 'true'"
 			  EchoOff='true'
 			  StandardErrorImportance='high'
 			  StandardOutputImportance='low'
@@ -297,8 +297,8 @@
       <_IsGitWorkTree>$(_GitIsWorkTree.Trim())</_IsGitWorkTree>
     </PropertyGroup>
 
-    <Exec Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' == 'true'"
-			  Command='$(GitExe) rev-parse --git-common-dir'
+    <Exec Command='$(GitExe) rev-parse --git-common-dir'
+			  Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' == 'true'"
 			  EchoOff='true'
 			  StandardErrorImportance='high'
 			  StandardOutputImportance='low'
@@ -1036,8 +1036,8 @@
     </PropertyGroup>
 
     <!-- If we didn't find it in the PATH nor the above locations, check for git installed in WSL -->
-    <Exec Condition="'$(GitExe)' == ''"
-			  Command='"$(MSBuildThisFileDirectory)wslrun.cmd" git --version'
+    <Exec Command='"$(MSBuildThisFileDirectory)wslrun.cmd" git --version'
+			  Condition="'$(GitExe)' == ''"
 			  EchoOff='true'
 			  ContinueOnError='true'
 			  StandardErrorImportance='high'

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -420,7 +420,7 @@
 			Condition="'$(GitRoot)' != '' and '$(GitRepositoryUrl)' == ''">
 
     <Exec Command="$(GitExe) config --get remote.$(GitRemote).url"
-			  Condition="'$(GitRepositoryUrl)' == ''"
+			  EchoOff="true"
 			  StandardErrorImportance="low"
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"


### PR DESCRIPTION
I discovered a rogue command echo while debugging a build this week.

I also took the opportunity to reorder command conditions, both to be consistent and it happens to be better for code search as it always shows the command when searching text for `<Exec `, for example.

Finally, I see the whitespace is very inconsistent with a mix of spaces and tabs, and a mix of indentations from 2 to 4 spaces. I was tempted to clean this up too - let me know if you would take a pull request for that, and if so what are your preferences either way. 😛 