### PR TITLE
Remove redundant depends on targets

### DIFF
--- a/src/GitInfo/build/GitInfo.AssemblyInfo.targets
+++ b/src/GitInfo/build/GitInfo.AssemblyInfo.targets
@@ -22,25 +22,10 @@
 
   <!-- Private properties -->
   <PropertyGroup>
-    <CoreCompileDependsOn>
-      GitInfo;
-      GitVersion;
-      GitThisAssembly;
-      GitInfoReport;
-      $(CoreCompileDependsOn)
-    </CoreCompileDependsOn>
+    <CoreCompileDependsOn Condition="'$(GitThisAssembly)' == 'true'">GitThisAssembly;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <GitThisAssemblyDependsOn>
-      GitInfo;
-      GitVersion;
-      _GitInputs;
-      _GitGenerateThisAssembly
-    </GitThisAssemblyDependsOn>
-  </PropertyGroup>
-
-  <Target Name="GitThisAssembly" DependsOnTargets="$(GitThisAssemblyDependsOn)"
+  <Target Name="GitThisAssembly" DependsOnTargets="GitVersion;_GitGenerateThisAssembly"
 			BeforeTargets="BuildOnlySettings" Condition="'$(GitThisAssembly)' == 'true'">
 
     <ItemGroup Condition="'$(Language)' != 'F#'">

--- a/src/GitInfo/build/GitInfo.AssemblyMetadata.targets
+++ b/src/GitInfo/build/GitInfo.AssemblyMetadata.targets
@@ -6,11 +6,11 @@
               for Git information.
 
 	$(GitThisAssemblyMetadata): set to 'false' to prevent assembly
-  								metadata generation. Defaults to 'false'.           
+  								metadata generation. Defaults to 'false'.
 	==============================================================
 	-->
 
-  <Target Name="GitAssemblyMetadata" DependsOnTargets="GitInfo;GitVersion" BeforeTargets="BuildOnlySettings">
+  <Target Name="GitAssemblyMetadata" DependsOnTargets="GitVersion" BeforeTargets="BuildOnlySettings">
 
     <ItemGroup Condition="'$(Language)' != 'VB'">
       <AssemblyMetadata Include="GitInfo.IsDirty"

--- a/src/GitInfo/build/GitInfo.ThisAssembly.targets
+++ b/src/GitInfo/build/GitInfo.ThisAssembly.targets
@@ -17,20 +17,7 @@
 
   <!-- Private properties -->
   <PropertyGroup>
-    <CoreCompileDependsOn>
-      GitInfo;
-      GitVersion;
-      GitThisAssembly;
-      GitInfoReport;
-      $(CoreCompileDependsOn)
-    </CoreCompileDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <GitThisAssemblyDependsOn>
-      GitInfo;
-      GitVersion;
-    </GitThisAssemblyDependsOn>
+    <CoreCompileDependsOn Condition="'$(GitThisAssembly)' == 'true'">GitThisAssembly;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +25,7 @@
     <CompilerVisibleProperty Include="GitThisAssembly" />
   </ItemGroup>
 
-  <Target Name="GitThisAssembly" DependsOnTargets="$(GitThisAssemblyDependsOn)"
+  <Target Name="GitThisAssembly" DependsOnTargets="GitVersion"
 			    BeforeTargets="PrepareConstants;GenerateMSBuildEditorConfigFileShouldRun" Condition="'$(GitThisAssembly)' == 'true'">
 
     <ItemGroup>
@@ -46,13 +33,13 @@
       <Constant Include="IsDirtyString" Value="false" Root="Git" Condition="$(GitIsDirty) == '0'" />
 
       <Constant Include="RepositoryUrl" Value="$(GitRepositoryUrl)" Root="Git" />
-      
+
       <Constant Include="Branch" Value="$(GitBranch)" Root="Git" />
       <Constant Include="Commit" Value="$(GitCommit)" Root="Git" />
       <Constant Include="Sha" Value="$(GitSha)" Root="Git" />
       <Constant Include="CommitDate" Value="$(GitCommitDate)" Root="Git" />
       <Constant Include="Commits" Value="$(GitCommits)" Root="Git" />
-      
+
       <Constant Include="Tag" Value="$(GitTag)" Root="Git" />
       <Constant Include="BaseTag" Value="$(GitBaseTag)" Root="Git" />
       <Constant Include="BaseVersion.Major" Value="$(GitBaseVersionMajor)" Root="Git" />
@@ -64,8 +51,8 @@
       <Constant Include="SemVer.Label" Value="$(GitSemVerLabel)" Root="Git" />
       <Constant Include="SemVer.DashLabel" Value="$(GitSemVerDashLabel)" Root="Git" />
       <Constant Include="SemVer.Source" Value="$(GitSemVerSource)" Root="Git" />
-    </ItemGroup>    
-    
+    </ItemGroup>
+
   </Target>
 
 </Project>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -136,16 +136,9 @@
     <GitCommitDateFormat Condition="'$(GitCommitDateFormat)' == '' And '$(OS)' != 'Windows_NT'">%cI</GitCommitDateFormat>
   </PropertyGroup>
 
-
   <!-- Private properties -->
   <PropertyGroup>
-    <CoreCompileDependsOn>
-      GitInfo;
-      GitVersion;
-      GitThisAssembly;
-      GitInfoReport;
-      $(CoreCompileDependsOn)
-    </CoreCompileDependsOn>
+    <CoreCompileDependsOn>GitVersion;GitInfoReport;$(CoreCompileDependsOn)</CoreCompileDependsOn>
 
     <!-- Cache file used to avoid running all git commands. Only GitRoot will be retrieved to determine the path of this cache file. -->
     <_GitInfoFile>$(GitCachePath)GitInfo.cache</_GitInfoFile>
@@ -157,7 +150,7 @@
     <_GitHeadFile>$(GitCachePath)GitHead.cache</_GitHeadFile>
   </PropertyGroup>
 
-  <Target Name="GitInfoReport" DependsOnTargets="GitInfo;GitVersion">
+  <Target Name="GitInfoReport" DependsOnTargets="GitVersion">
     <Message Importance="$(GitInfoReportImportance)" Text="Git Info:
   GitInfoBaseDir:       $(GitInfoBaseDir)
   GitRoot:              $(GitRoot)


### PR DESCRIPTION
Reduces build log noise by removing redundant "depends on" targets. Leverages known transitive target dependencies as follows:
* `GitThisAssembly` -> `GitVersion`
* `GitVersion` -> `GitInfo`

Removes `GitThisAssemblyDependsOn` property to use simplified inline `DependsOnTargets` attribute.
Changes `CoreCompileDependsOn` modifications to conditionally inject  `GitThisAssembly` target.