### PR TITLE
Allow opting-out of GitBranch default in CI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,6 +205,8 @@ to customize the behavior:
 
   $(GitRemote): name of remote to get repository url for. Defaults to 'origin'.
 
+  $(GitBranchCI): determines whether the branch name should be populated from default environment variables used by the CI system. Default to 'true'.
+
   $(GitDefaultBranch): determines the base branch used to calculate commits on top of current branch. Defaults to 'main'.
 
   $(GitVersionFile): determines the name of a file in the Git repository root used to provide the base version info. Defaults to 'GitInfo.txt'.

--- a/src/GitInfo/build/GitInfo.CI.targets
+++ b/src/GitInfo/build/GitInfo.CI.targets
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+  <!--
+  Uses well-known documented CI systems branch names to determine the current Git branch.
+  Can be disabled by setting the GitBranchCI=false property, or setting GitBranch to a specific value.
+  -->
   <PropertyGroup Condition="'$(GitBranch)' == ''">
     <!-- GitHub Actions: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables -->
     <GitBranch Condition="'$(GitBranch)' == '' and '$(GITHUB_REF)' != '' and $(GITHUB_REF.Contains('refs/pull/'))">pr$(GITHUB_REF.Replace('refs/pull/', '').Replace('/merge', ''))</GitBranch>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -23,6 +23,8 @@
 
   $(GitDefaultBranch): determines the base branch used to calculate commits on top of current branch. Defaults to 'main'.
 
+  $(GitBranchCI): determines whether the branch name should be populated from default environment variables used by the CI system. Default to 'true'.
+
   $(GitVersionFile): determines the name of a file in the Git repository root used to provide the base version info. Defaults to 'GitInfo.txt'.
 
   $(GitCommitsRelativeTo): optionally specifies an alternative directory for counting commits on top of the base version. Defaults to the $(GitVersionFile) directory.
@@ -116,7 +118,7 @@
                    '$(BUDDY)' == 'true'">true</CI>
   </PropertyGroup>
 
-  <Import Project="GitInfo.CI.targets" Condition="$(CI)" />
+  <Import Project="GitInfo.CI.targets" Condition="$(CI) and $(GitBranchCI) != 'false'" />
 
   <Target Name="GitInfoReport" DependsOnTargets="GitVersion">
     <Message Importance="$(GitInfoReportImportance)" Text="Git Info:

--- a/src/GitInfo/readme.txt
+++ b/src/GitInfo/readme.txt
@@ -95,6 +95,8 @@ Available MSBuild customizations:
     * You can get a list of your remotes by running `git remote -v` in your shell when inside your git repo.
     * Defaults to 'origin'.
   
+  $(GitBranchCI): 
+    * Determines whether the branch name should be populated from default environment variables used by the CI system. Default to 'true'.
 
   $(GitDefaultBranch):
     * Specifies the base branch which is compared to your current branch (at time of build) to determine how many commits ahead the current branch is compared to base.


### PR DESCRIPTION
This should allow the old behavior, in case the new defaults disrupt some existing functionality.