### PR TITLE
fix: prevent transitive ThisAssembly.Constants deps from copying assemblies to output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: 🧪 test
         shell: pwsh
-        run: dnx --yes retest -- --no-build
+        run: dotnet dnx --yes retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: 🧪 test
         shell: pwsh
-        run: dnx --yes retest -- --no-build
+        run: dotnet dnx --yes retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+:bug: Fixed bugs:
+
+- Assemblies of transitive nuget dependencies are placed into the build folder [\#389](https://github.com/devlooped/GitInfo/issues/389)
+
 ## [v3.6.0](https://github.com/devlooped/GitInfo/tree/v3.6.0) (2025-10-17)
 
 [Full Changelog](https://github.com/devlooped/GitInfo/compare/v3.6.0-beta...v3.6.0)

--- a/src/GitInfo/GitInfo.msbuildproj
+++ b/src/GitInfo/GitInfo.msbuildproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="NuGetizer" Version="1.4.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly.Constants" Version="2.1.2" Pack="true" TargetFramework="netstandard2.0" />
+    <PackageReference Include="ThisAssembly.Constants" Version="2.1.2" Pack="true" PrivateAssets="all" IncludeAssets="build;analyzers" TargetFramework="netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build/**/*.*" />

--- a/src/GitInfo/buildMultiTargeting/GitInfo.targets
+++ b/src/GitInfo/buildMultiTargeting/GitInfo.targets
@@ -4,6 +4,9 @@
     <!-- Make sure we're always private to the referencing project. Prevents analyzers from "flowing out" of the referencing project. -->
     <PackageReference Update="GitInfo" PrivateAssets="all" PackTransitive="false" />
 
+    <!-- Ensure ThisAssembly.Constants (a dependency) is only used for build/analyzers to avoid bringing its transitive runtime assemblies (e.g. System.Threading.Tasks.Extensions.dll, System.Runtime.CompilerServices.Unsafe.dll) into the build output. See https://github.com/devlooped/GitInfo/issues/389 -->
+    <PackageReference Update="ThisAssembly.Constants" PrivateAssets="all" IncludeAssets="build;analyzers" />
+
     <!-- This makes sure we don't enforce SponsorLink transitively, but only when consumers are directly referencing our package. -->
     <SponsorablePackageId Include="GitInfo" />
 

--- a/src/GitInfo/buildTransitive/GitInfo.targets
+++ b/src/GitInfo/buildTransitive/GitInfo.targets
@@ -4,6 +4,9 @@
     <!-- Make sure we're always private to the referencing project. Prevents analyzers from "flowing out" of the referencing project. -->
     <PackageReference Update="GitInfo" PrivateAssets="all" PackTransitive="false" />
 
+    <!-- Ensure ThisAssembly.Constants (a dependency) is only used for build/analyzers to avoid bringing its transitive runtime assemblies (e.g. System.Threading.Tasks.Extensions.dll, System.Runtime.CompilerServices.Unsafe.dll) into the build output. See https://github.com/devlooped/GitInfo/issues/389 -->
+    <PackageReference Update="ThisAssembly.Constants" PrivateAssets="all" IncludeAssets="build;analyzers" />
+
     <!-- This makes sure we don't enforce SponsorLink transitively, but only when consumers are directly referencing our package. -->
     <SponsorablePackageId Include="GitInfo" />
 


### PR DESCRIPTION
Fixes https://github.com/devlooped/GitInfo/issues/389

## Problem

Assemblies from transitive dependencies of ThisAssembly.Constants (`System.Runtime.CompilerServices.Unsafe.dll` and `System.Threading.Tasks.Extensions.dll`) were being placed into the consumer project's build output folder, even when using the recommended `PrivateAssets="all"` on the GitInfo package reference (and even on modern .NET Framework targets like net472).

This started happening in 3.2.0 when GitInfo began depending on ThisAssembly.Constants to generate the `ThisAssembly.Git.*` constants.

## Solution

- Restrict the PackageReference to ThisAssembly.Constants (in the authoring .msbuildproj) to only `build` and `analyzers` assets.
- Add `PackageReference Update` rules in `buildTransitive` and `buildMultiTargeting` targets to enforce `PrivateAssets="all" IncludeAssets="build;analyzers"` on ThisAssembly.Constants for all consumers of GitInfo.
- This ensures the generator runs (so Git constants are still produced) without pulling in its runtime shim dependencies as CopyLocal assemblies.

The generated package dependency now declares the limited assets, and the update rules ensure enforcement.

Verified:
- Clean `bin/` output (no unwanted DLLs) on net472 repros, with and without PrivateAssets on GitInfo ref.
- `ThisAssembly.Git.*` constants continue to generate and function correctly.