### PR TITLE
Fix occasional build failures with shared GitInfo.cache under parallel builds (#390)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 :bug: Fixed bugs:
 
 - Assemblies of transitive nuget dependencies are placed into the build folder [\#389](https://github.com/devlooped/GitInfo/issues/389)
+- Build occasionally fails when using shared GitInfo.cache with parallel builds (msbuild /m) [\#390](https://github.com/devlooped/GitInfo/issues/390)
 
 ## [v3.6.0](https://github.com/devlooped/GitInfo/tree/v3.6.0) (2025-10-17)
 

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -337,12 +337,12 @@
       <Output ItemName="_GitInput" TaskParameter="Include" />
     </CreateItem>
 
-    <Delete Files="$(_GitInfoFile)" Condition="Exists('$(_GitInfoFile)') and '$(SkipReadGitCache)' == 'true'" />
+    <Delete Files="$(_GitInfoFile)" Condition="Exists('$(_GitInfoFile)') and '$(SkipReadGitCache)' == 'true'" ContinueOnError="true" />
   </Target>
 
   <!-- If the inputs/outputs are outdated, clear the cache. -->
   <Target Name="_GitClearCache" Inputs="@(_GitInput)" Outputs="$(_GitInfoFile)" Condition="Exists('$(_GitInfoFile)')">
-    <Delete Files="$(_GitInfoFile)" />
+    <Delete Files="$(_GitInfoFile)" ContinueOnError="true" />
   </Target>
 
   <Target Name="_GitReadCache" Condition="Exists('$(_GitInfoFile)') and '$(SkipReadGitCache)' != 'true'">
@@ -859,9 +859,9 @@
       <_GitInfoFileDir>$([System.IO.Path]::GetDirectoryName('$(_GitInfoFile)'))</_GitInfoFileDir>
     </PropertyGroup>
 
-    <MakeDir Directories="$(_GitInfoFileDir)" Condition="!Exists('$(_GitInfoFileDir)')" />
+    <MakeDir Directories="$(_GitInfoFileDir)" Condition="!Exists('$(_GitInfoFileDir)')" ContinueOnError="true" />
 
-    <WriteLinesToFile File="$(_GitInfoFile)" Lines="$(_GitInfoContent)" Overwrite="true" />
+    <WriteLinesToFile File="$(_GitInfoFile)" Lines="$(_GitInfoContent)" Overwrite="true" ContinueOnError="true" />
 
     <ItemGroup>
       <FileWrites Include="$(_GitInfoFile)" />


### PR DESCRIPTION
When using a shared `$(GitCachePath)` (e.g. solution-level `obj/`) with `msbuild /m`,
multiple projects can race on clearing/writing `GitInfo.cache`, leading to
`MSB3491: Could not write lines to file ... The process cannot access the file because it is being used by another process`.

- Add `ContinueOnError="true"` to `Delete` (in `_GitClearCache` and skip-read), `MakeDir`, and `WriteLinesToFile` (in `_GitWriteCache`)
  for the shared cache files (consistent with prior race fixes for `IsDirty.cache` and read paths, see #321).
- This makes the write failure non-fatal; one concurrent writer succeeds,
  values are already computed in-memory for all projects, and the up-to-date marker is updated.
- Updated changelog.

Fixes #390